### PR TITLE
Try to fix the PyPy builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - pypy
   - pypy3
 install: pip install tox-travis coveralls
+env: CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
 script: tox
 after_success:
   - coverage combine

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,9 @@ deps =
   pypy: pytest < 5.0
   pytest-cov
   pytest-flake8
-passenv = LDFLAGS CFLAGS
+passenv =
+  LDFLAGS
+  CFLAGS
+  CRYPTOGRAPHY_ALLOW_OPENSSL_102
 commands = py.test --cov=src {posargs}
 usedevelop = True


### PR DESCRIPTION
`CRYPTOGRAPHY_ALLOW_OPENSSL_102` allows to use openSSL 1.0.2 for the current version of `cryptography`. Hopefully we have a newer openSSL version when the next version of `cryptography` appears.